### PR TITLE
fix build break and incorect OpenWatcom configuration

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -40,7 +40,7 @@ How to target ELKS using owtarget16:
 * In a terminal window:
   * Run: git clone https://github.com/pts/owtarget16
   * cd into the extracted directory containing binl/owcc.
-  * Run: export WATCOM="$PWD"; export PATH="$WATCOM/binl:$PATH" INCLUDE="$WATCOM/h"
+  * Run: export WATCOM="$PWD"; export PATH="$WATCOM/binl:$PATH" INCLUDE="$WATCOM/lh"
   * cd to the owtarget16 directory (created by `git clone' above).
   * Run: ./compile.sh
 * To try the example programs, in the same terminal window:

--- a/compile.sh
+++ b/compile.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # gcc -W -Wall -s -O2 -o prog16cv prog16cv.c  # Any host.
-owcc -W -Wall -Wextra -s -O2 -fno-stack-check -o prog16cv prog16cv.c  # For the Linux host.
+owcc -Wall -Wextra -s -O2 -fno-stack-check -o prog16cv prog16cv.c  # For the Linux host.
 
 for PROG in hello printarg rot13; do
   # There is no -nostdinc.
@@ -11,7 +11,7 @@ for PROG in hello printarg rot13; do
   # -Wl,disable -Wl,1014  hides this: Warning! W1014: stack segment not found
   # !! Specify the stack size in the .c file (?).
   # Stack size: 0x400 is enough, 0x380 seems to be too low (fails with `"$PROG": Out of space) in ELKS 0.2.0.
-  owcc -bos2 -fnostdlib -Wl,disable -Wl,1014 -Wl,option -Wl,start=_start_ -Wl,option -Wl,dosseg -Wl,option -Wl,stack=0x400 -Os -s -fno-stack-check -march=i86 -W -Wall -Wextra -o "$PROG".os2 "$PROG".c
+  owcc -bos2 -march=i86 -I${WATCOM}/h -fnostdlib -Wl,disable -Wl,1014 -Wl,option -Wl,start=_start_ -Wl,option -Wl,dosseg -Wl,option -Wl,stack=0x400 -Os -s -fno-stack-check -Wall -Wextra -o "$PROG".os2 "$PROG".c
   ./prog16cv -f elks -o "$PROG".elks "$PROG".os2
   rm -f "$PROG".os2
 done

--- a/prog16cv.c
+++ b/prog16cv.c
@@ -13,10 +13,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#if defined(__WATCOMC__) && defined(__LINUX__)
-#undef O_BINARY  /* Work around OpenWatcom libc bug. */
-#endif
-
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif


### PR DESCRIPTION
your code is not compilable due to you use -W option which is not valid for owcc utility.

You wrote in your code prog16cv.c
```
 #if defined(__WATCOMC__) && defined(__LINUX__)
 #undef O_BINARY  /* Work around OpenWatcom libc bug. */
 #endif
```
It is not valid. You have a trouble due to wrongly configured OpenWatcom.

You have a mistake in configuration for Linux, you export h subdir, but correct is export INCLUDE=${WATCOM}/lh.

In your case prog16cv.c is compiled for Linux host therefore must use lh subdir other programs are compiled for 16-bit OS/2 target therefore must use h subdir